### PR TITLE
chore: remove Google Analytics environment variable from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,9 +23,7 @@ FROM base AS builder
 ARG STRAPI_URL=https://strapi.aniss.dev
 ENV STRAPI_URL=${STRAPI_URL}
 
-# Google Analytics
-ARG NEXT_PUBLIC_MEASUREMENT_ID=G-V4TGQXD8PE
-ENV NEXT_PUBLIC_MEASUREMENT_ID=${NEXT_PUBLIC_MEASUREMENT_ID}
+
 
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules


### PR DESCRIPTION
- Deleted the NEXT_PUBLIC_MEASUREMENT_ID ARG and ENV lines from the Dockerfile.